### PR TITLE
refacto(Calc): split responsibilites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# CHANGELOG
+
+## [Unreleased]
+
+### Added
+
+- run() method to handle the running loop.
+
+
+### Changed
+
+- methods other than run are marked private
+- extracted the loop from __init__
+- split responsibilities in small functions
+- if invalid output, message does not display ValueError as it would look like an exception
+- removed all the nesting (while True + recursion) in the ask_again, now renamed _continue
+
+### Fixed

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 It is my Second little program using Python - OOP
 
-On Terminal, you will be able to make simple calculations
+In Terminal, you will be able to make simple calculations
+
+## Usage
+
+in a terminal, run a python REPL with
+
+``` bash
+    python3
+```
+
+then type
+
+```python 
+    import main
+```
+
 
 Or got to : [Programiz](https://www.programiz.com/python-programming/online-compiler/) and Copy/Paste code from "main.py" to Programiz

--- a/main.py
+++ b/main.py
@@ -1,57 +1,66 @@
 # module to get aplhabet
 import string
 
-# put all alphabeth into a list
-alphabet = list(string.ascii_letters)
-
 """_summary_
 """
-# print(numbers)
+
 
 class Calc:
+    ALPHABET = list(string.ascii_letters)
+
+    # __init__ job is to initialize instance variables.
+    # it should not have more responsibility
     def __init__(self) -> None:
         # will take all calculations and results
-        self.all_calc = {}
+        self.calculations_history = {}
+        self.input = None
+        self.result = None
 
+    def run(self):
         while True:
-            self.calculate()
-            self.ask_again()
-
-    def calculate(self):
-        calc = input(" ---> ")
-        elements = []
-        result = ""
-        
-        if calc == "":
-            return self.calculate()
-        # separate all elements of input
-        for char in calc:
-            elements.append(char)
-        # check if a letter of alphabet is find on input
-        if any(char in elements for char in alphabet):
-            # if True :
-            print("ValueError : You must use only numbers and operators ")
-            return self.calculate()
-        # if False :
-        # get cacul to str
-        result = eval(result.join(elements))
-        # transform str value to obj -> calculate
-        self.all_calc[f"{calc}"] = result
-        print(result)
-        
-    def ask_again(self):
-        answer = input("Do you want to continue ? ( Y / N ) -> ").lower()
-        while True:
-            if answer == 'y':
+            self._display_prompt()
+            self._get_user_input()
+            if not self._valid_input():
+                print('You must use only numbers and operators ")')
+                continue
+            self._calculate()
+            self._display_result()
+            self._save_operation()
+            if not self._continue():
                 break
-            elif answer == 'n':
-                # TODO: show caculs and all results --> self.all_calc
-                print("Your calculations were :")
-                for key, value in self.all_calc.items():
-                    print("   ",key," -> ", value)
-                exit(0)
-            else: 
-                return self.ask_again()
+        self._display_history()
+        exit(0)
+
+    @staticmethod
+    def _display_prompt():
+        print('---> ', end='')
+
+    def _get_user_input(self):
+        self.input = input()
+
+    def _calculate(self):
+        self.result = eval(''.join(self.input))
+
+    def _display_result(self):
+        print(self.result)
+
+    def _valid_input(self):
+        return not any(char in self.input for char in Calc.ALPHABET)
+
+    def _save_operation(self):
+        self.calculations_history[f"{self.input}"] = self.result
+
+    def _continue(self):
+        answer = input("Do you want to continue ? ( Y / N ) -> ").lower()
+        options = {'y': True, 'n': False}
+        if answer not in options.keys():
+            return self._continue()
+        return options[answer]
+
+    def _display_history(self):
+        print("Your calculations were:")
+        for key, value in self.calculations_history.items():
+            print(f"{key} -> {value}")
 
 
-Calc()
+Calc().run()


### PR DESCRIPTION
Hello
I saw your post on linkedin.

First, good job for making something that works. And good idea to ask for help.
I m not an expert but I try to be better everyday

______

I refactored the code a little (too much) so you can see a different point of view.
I split the responsibilities, because a method/function should do only one thing and do it well.

the run method i added show the whole process but in a human readable way.
It only calls high level function (beside the print)

and the lower level process are handled by other methods.

The method calculate now calculates. has it should be expected by a user

If you want to modify the prompt from ---> to something else, like #####>>>> It surely makes more sense to modify `display_prompt` than `calculate`


same way with the input validation. If you later want to change the rules and say accept the usage of "pi"
it is easier to modify a one-line function that to dive in the `calculate` method and get lost in all the code
